### PR TITLE
Add ldml.dtd to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(name='palaso',
       package_data={'palaso.sfm':['usfm.sty'], 'palaso.kmn':['keyboard.svg'], 
                     'palaso.collation' : ['sort_trainer.glade'],
                     'palaso.sldr': ['allkeys.txt', 'language-subtag-registry.txt',
-                                    'likelySubtags.xml', 'supplementalData.xml',
+                                    'ldml.dtd', 'likelySubtags.xml',
+                                    'supplementalData.xml',
                                     'supplementalMetadata.xml']}
      )
 


### PR DESCRIPTION
`ldml.dtd` is used by [lib/palaso/sldr/ldml.py](https://github.com/silnrsi/palaso-python/blob/05e869105413c78cd4c484cdf8813a0702bd94b7/lib/palaso/sldr/ldml.py#L414).